### PR TITLE
Making Kendra index Id mandatory for MS Finder stack

### DIFF
--- a/cfn-templates/msfinder.yaml
+++ b/cfn-templates/msfinder.yaml
@@ -434,6 +434,8 @@ Resources:
 Parameters:
   KendraIndexId:
     Type: String
+    AllowedPattern : ".+"
+    ConstraintDescription: "Kendra Index id cannot be blank"
   MediaBucketNames:
     Type: CommaDelimitedList
     Default: "<SAMPLES_BUCKET>"


### PR DESCRIPTION
Making Kendra Index Id mandatory. MS Finder stack must have a valid Kendra Index Id. The index Id is used to enable access tokens. 