### PR TITLE
Fix for Issues#38 and Issue#39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2024-02-07
+### Fixed
+- Fix for Issue#38 - Prevent YT Media download and transcription if already present in ytindexer DynamoDB table
+- Fix for Issue#39 - Prevent YT Media download operation if unavailable
+
 ## [0.3.5] - 2024-01-22
 ### Fixed
 - Cleaning up Layers directory prior to install, Fixed Pip version check, Updated Readme
@@ -39,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/aws-samples/aws-kendra-transcribe-media-search/compare/v0.3.5...develop
+[Unreleased]: https://github.com/aws-samples/aws-kendra-transcribe-media-search/compare/v0.3.6...develop
+[0.3.6]: https://github.com/aws-samples/aws-kendra-transcribe-media-search/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/aws-samples/aws-kendra-transcribe-media-search/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/aws-samples/aws-kendra-transcribe-media-search/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/aws-samples/aws-kendra-transcribe-media-search/compare/v0.3.2...v0.3.3

--- a/lambda/indexer/crawler.py
+++ b/lambda/indexer/crawler.py
@@ -330,16 +330,17 @@ def lambda_handler(event, context):
             for s3url in s3mediaobjects.keys():
                 process_s3_media_object(STACK_NAME, bucket, s3url, s3mediaobjects.get(s3url), s3metadataobjects.get(s3url), s3transcribeoptsobjects.get(s3url), kendra_sync_job_id, TRANSCRIBE_ROLE)
                 s3files.append(s3url)
-            # detect and delete indexed docs where files that are no longer in the source bucket location
-            # reasons: file deleted, or indexer config updated to crawl a new location
-            logger.info("** Process deletions **")
-            process_deletions(DS_ID, INDEX_ID, kendra_sync_job_id=kendra_sync_job_id, s3files=s3files)
         except Exception as e:
             logger.error("Exception: " + str(e))
             put_crawler_state(STACK_NAME, 'STOPPED')            
             stop_kendra_sync_job_when_all_done(dsId=DS_ID, indexId=INDEX_ID)
             return exit_status(event, context, cfnresponse.FAILED)
 
+    # detect and delete indexed docs where files that are no longer in the source bucket location
+    # reasons: file deleted, or indexer config updated to crawl a new location
+    logger.info("** Process deletions **")
+    process_deletions(DS_ID, INDEX_ID, kendra_sync_job_id=kendra_sync_job_id, s3files=s3files)
+    
     # Stop crawler
     logger.info("** Stop crawler **")
     put_crawler_state(STACK_NAME, 'STOPPED')

--- a/lambda/ytindexer/index.py
+++ b/lambda/ytindexer/index.py
@@ -45,11 +45,13 @@ def exit_status(event, context, status):
                cfnresponse.send(event, context, status, {}, None)
     return status
 
-def updateDDBTable(videoMetaData):    
-    tableName = os.environ['ddbTableName']
-    table = dynamodb.Table(tableName)
-    for video in videoMetaData['entries']:
-        video_id = video['id']
+def download_and_upload(ydl,video,table):    
+    try:
+        ydl.download([video['webpage_url']])
+        s3_client = boto3.client('s3', region) 
+        logger.info('Uploading to s3 media bucket ->'+mediaFolderPrefix+video['id']+'.mp3')
+        s3_client.upload_file(SAVE_PATH+'/'+video['id']+'.mp3', mediaBucket, mediaFolderPrefix+video['id']+'.mp3')
+        # Update the DynamoDB table    
         title = video['title']
         uploader = video['uploader'] 
         upload_date = video['upload_date']
@@ -57,40 +59,56 @@ def updateDDBTable(videoMetaData):
         view_count = video['view_count']  
         date_obj = datetime.strptime(upload_date, "%Y%m%d")
         iso_upload_date = date_obj.isoformat()
-
         try:
             response = table.put_item(
                     Item={
-                            'ytkey': video_id,
+                            'ytkey': video['id'],
                             'downloaded': True,
                             'ytauthor': uploader,
                             'video_length': duration,
                             'publish_date': iso_upload_date,
                             'view_count': view_count,
-                            'source_uri': ytcommonURL+video_id,
+                            'source_uri': ytcommonURL+video['id'],
                             'title': title 
                         },
                         ConditionExpression='attribute_not_exists(ytkey)'
                 )            
         except ClientError as e:
             if e.response['Error']['Code']=='ConditionalCheckFailedException':  
-                logger.info("Youtube Video "+ytcommonURL+video_id+" has already been indexed")
+                logger.info("Youtube Video "+ytcommonURL+video['id']+" has already been indexed")
         except Exception as e:
-            logger.error('ERROR: Could not index video '+ytcommonURL+video_id+' ->'+str(e))
+            logger.error('ERROR: Could not index video '+ytcommonURL+video['id']+' ->'+str(e))
             return 1
         try:
-            json_dump = json.dumps({'Attributes': {'_source_uri':ytcommonURL+video_id, '_category':'YouTube video', '_created_at':iso_upload_date,'video_length':duration,'video_view_count':view_count,'ytauthor':uploader,'ytsource':ytcommonURL+video_id},
+            json_dump = json.dumps({'Attributes': {'_source_uri':ytcommonURL+video['id'], '_category':'YouTube video', '_created_at':iso_upload_date,'video_length':duration,'video_view_count':view_count,'ytauthor':uploader,'ytsource':ytcommonURL+video['id']},
                                 'Title': title
                                 })
             encoded_string = json_dump.encode("utf-8")
-            file_name = metaDataFolderPrefix+video_id+".mp3.metadata.json"
+            file_name = metaDataFolderPrefix+video['id']+".mp3.metadata.json"
             s3_path = file_name
             s3 = boto3.resource("s3")
-            logger.info('Uploading to s3 media bucket ->'+metaDataFolderPrefix+video_id+'.mp3.metadata.json')
+            logger.info('Uploading to s3 media bucket ->'+metaDataFolderPrefix+video['id']+'.mp3.metadata.json')
             s3.Bucket(mediaBucket).put_object(Key=s3_path, Body=encoded_string)
         except Exception as e:
             logger.error("Could not upload the metadata json to S3" + str(e) )
-            return 2
+            return 2        
+    except Exception as e:
+        body='ERROR: Could not upload Audio to S3->'+str(e)
+        logger.error(body)
+    return 0
+
+
+def updateDDBTable(ydl,videoMetaData):    
+    tableName = os.environ['ddbTableName']
+    table = dynamodb.Table(tableName)
+    for video in videoMetaData['entries']:
+        video_id = video['id']
+        response = table.get_item(Key={'ytkey': video_id})
+        if 'Item' not in response:
+            logger.info("Youtube Video ID "+video_id+" has not been indexed yet. Downloading media.")
+            download_and_upload(ydl,video,table)
+        else:
+            logger.info("Youtube Video ID "+video_id+" has already been indexed. Skipping media.")
     return 0
 
 def empty_bucket(mediaBucket,event, context):
@@ -121,7 +139,7 @@ def lambda_handler(event, context):
     region = os.environ['AWS_REGION']
     numberOfYTVideos = int(os.environ['numberOfYTVideos'])
     ydl_opts = {
-            'format': 'bestaudio',
+            'format': 'bestaudio/best',
             'cachedir': SAVE_PATH,
             'outtmpl': SAVE_PATH+'/%(id)s.%(ext)s',
             'postprocessors': [{
@@ -131,33 +149,13 @@ def lambda_handler(event, context):
             }],
             'playlistend': numberOfYTVideos
             }
-            
+
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         try:
-            ydl.download([playListURL])
-        except Exception as e:
-            logger.error('ERROR: Could not index videos from playlist ->'+str(e))
-            return exit_status(event, context, cfnresponse.FAILED)
-        try:
             videoMetaData = ydl.extract_info(playListURL, download=False)
+            returnVal = updateDDBTable(ydl,videoMetaData)
         except Exception as e:
             logger.error('ERROR: Could not extract metadata from YT videos ->'+str(e))
             return exit_status(event, context, cfnresponse.FAILED)
-        for video in videoMetaData['entries']:
-            video_id = video['id']
-            # Upload downloaded mp3 files to S3
-            try:
-                s3_client = boto3.client('s3', region) 
-                logger.info('Uploading to s3 media bucket ->'+mediaFolderPrefix+video_id+'.mp3')
-                s3_client.upload_file(SAVE_PATH+'/'+video_id+'.mp3', mediaBucket, mediaFolderPrefix+video_id+'.mp3')
-            except Exception as e:
-                body='ERROR: Could not upload Audio to S3->'+str(e)
-                logger.error(body)
-            # Update the DynamoDB table    
-            try:
-                returnVal = updateDDBTable(videoMetaData)
-            except Exception as e:
-                logger.error('ERROR: Could not update DDB'+str(e))
-                return exit_status(event, context, cfnresponse.FAILED)
-            
+
     return exit_status(event, context, cfnresponse.SUCCESS)


### PR DESCRIPTION
*Issue #38

*Description of changes:*
The YT_DLP package is used to first check on the video ids within a playlist. The VideoID if not already indexed is downloaded and transcribed.

*Issue #39 

*Description of changes:*
Certain times YouTube playlists can have vidoes that are unavailable for download. This fix ignores unavailable videos without failing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
